### PR TITLE
Qualify outbound links

### DIFF
--- a/_includes/junit-intro.md
+++ b/_includes/junit-intro.md
@@ -5,7 +5,7 @@ It requires Java 17 and Kotlin 2.1 or above and enables many different styles of
 
 ### Resources
 
-<a href="https://blogs.oracle.com/java/2019-dukes-choice-award-winners" class="pull-right">
+<a rel="noopener" href="https://blogs.oracle.com/java/2019-dukes-choice-award-winners" class="pull-right">
     <img src="{{ site.baseurl }}/assets/img/dukes-choice-award.jpg" alt="Duke's Choice Award" width="170">
 </a>
 

--- a/_includes/junit-sponsoring.md
+++ b/_includes/junit-sponsoring.md
@@ -12,7 +12,7 @@ Your donations will help to make that a reality!
 <div align="center">
   <ul class="list-inline">
     <li>
-      <a class="cardgold" href="https://jb.gg/junit-logo">
+      <a class="cardgold" rel="nofollow noopener" href="https://jb.gg/junit-logo">
         <div class="cardgold-image">
           <img style="width:85%" src="assets/img/sponsor-logo-JetBrains.svg" alt="JetBrains">
         </div>
@@ -31,7 +31,7 @@ Your donations will help to make that a reality!
       </a>
     </li>
     <li>
-      <a class="cardgold" href="https://www.netflix.com">
+      <a class="cardgold" rel="nofollow noopener" href="https://www.netflix.com">
         <div class="cardgold-image">
           <img style="width:80%" src="assets/img/sponsor-logo-Netflix.svg" alt="Netflix">
         </div>
@@ -55,7 +55,7 @@ Your donations will help to make that a reality!
 <div align="center">
   <ul class="list-inline">
     <li>
-      <a class="cardsilver" href="https://www.micromata.de">
+      <a class="cardsilver" rel="nofollow noopener" href="https://www.micromata.de">
         <div class="cardsilver-image">
           <img style="width:90%" src="assets/img/sponsor-logo-Micromata.svg" alt="MICROMATA">
         </div>
@@ -69,7 +69,7 @@ Your donations will help to make that a reality!
       </a>
     </li>
     <li>
-      <a class="cardsilver" href="https://quo-digital.jp">
+      <a class="cardsilver" rel="nofollow noopener" href="https://quo-digital.jp">
         <div class="cardsilver-image">
           <img style="height:70%" src="assets/img/sponsor-logo-QuoCard.svg" alt="QUO CARD">
         </div>
@@ -89,7 +89,7 @@ Your donations will help to make that a reality!
 <div align="center">
   <ul class="list-inline">
     <li>
-      <a class="cardbronze" href="https://www.premium-minds.com">
+      <a class="cardbronze" rel="nofollow noopener" href="https://www.premium-minds.com">
         <div class="cardbronze-image">
           <img style="width:80%; padding-top:5px" src="assets/img/sponsor-logo-PremiumMinds.svg" alt="Premium Minds">
         </div>
@@ -103,7 +103,7 @@ Your donations will help to make that a reality!
       </a>
     </li>
     <li>
-      <a class="cardbronze" href="https://codefortynine.com">
+      <a class="cardbronze" rel="nofollow noopener" href="https://codefortynine.com">
         <div class="cardbronze-image">
           <img style="width:90%" src="assets/img/sponsor-logo-codefortynine.svg" alt="codefortynine">
         </div>
@@ -117,7 +117,7 @@ Your donations will help to make that a reality!
       </a>
     </li>
     <li>
-      <a class="cardbronze" href="https://www.infosupport.com">
+      <a class="cardbronze" rel="nofollow noopener" href="https://www.infosupport.com">
         <div class="cardbronze-image">
           <img style="width:80%; padding-top:10px" src="assets/img/sponsor-logo-InfoSupport.svg" alt="Info Support">
         </div>
@@ -131,7 +131,7 @@ Your donations will help to make that a reality!
       </a>
     </li>
     <li>
-      <a class="cardbronze" href="https://route4me.com">
+      <a class="cardbronze" rel="nofollow noopener" href="https://route4me.com">
         <div class="cardbronze-image">
           <img style="width:90%;" src="assets/img/sponsor-logo-Route4Me.svg" alt="Route4Me">
         </div>
@@ -145,7 +145,7 @@ Your donations will help to make that a reality!
       </a>
     </li>
     <li>
-      <a class="cardbronze" href="https://www.testiny.io">
+      <a class="cardbronze" rel="nofollow noopener" href="https://www.testiny.io">
         <div class="cardbronze-image">
           <img style="width:85%;" src="assets/img/sponsor-logo-Testiny.svg" alt="Testiny">
         </div>
@@ -159,7 +159,7 @@ Your donations will help to make that a reality!
       </a>
     </li>
     <li>
-      <a class="cardbronze" href="https://www.testmuai.com/?utm_medium=sponsor&utm_source=junit">
+      <a class="cardbronze" rel="nofollow noopener" href="https://www.testmuai.com/?utm_medium=sponsor&utm_source=junit">
         <div class="cardbronze-image">
           <img style="width:80%;" src="assets/img/sponsor-logo-TestMuAI.svg" alt="TestMu AI">
         </div>
@@ -173,7 +173,7 @@ Your donations will help to make that a reality!
       </a>
     </li>
     <li>
-      <a class="cardbronze" href="https://spinthewheel.io/">
+      <a class="cardbronze" rel="nofollow noopener" href="https://spinthewheel.io/">
         <div class="cardbronze-image">
           <img style="width:80%;" src="assets/img/sponsor-logo-SpinTheWheel.svg" alt="Spin the Wheel">
         </div>
@@ -187,7 +187,7 @@ Your donations will help to make that a reality!
       </a>
     </li>
     <li>
-      <a class="cardbronze" href="https://plinko.free/">
+      <a class="cardbronze" rel="nofollow noopener" href="https://plinko.free/">
         <div class="cardbronze-image">
           <img src="assets/img/sponsor-logo-Plinko.svg" alt="Plinko">
         </div>

--- a/index.html
+++ b/index.html
@@ -14,15 +14,15 @@ title: JUnit
       <i data-lucide="file-code" class="lucide-lg"></i>
       Javadoc
     </a></li>
-    <li><a class="btn btn-primary btn-lg" href="{{ site.current_repo_url }}/" role="button">
+    <li><a class="btn btn-primary btn-lg" rel="noopener" href="{{ site.current_repo_url }}/" role="button">
       <i data-lucide="git-compare-arrows" class="lucide-lg"></i>
       Code &amp; Issues
     </a></li>
-    <li><a class="btn btn-primary btn-lg" href="{{ site.current_repo_url }}/discussions/categories/q-a" role="button">
+    <li><a class="btn btn-primary btn-lg" rel="noopener" href="{{ site.current_repo_url }}/discussions/categories/q-a" role="button">
       <i data-lucide="messages-square" class="lucide-lg"></i>
       Q&thinsp;&amp;&thinsp;A
     </a></li>
-    <li><a class="btn btn-danger btn-lg" href="https://github.com/sponsors/junit-team" role="button">
+    <li><a class="btn btn-danger btn-lg" rel="noopener" href="https://github.com/sponsors/junit-team" role="button">
       <i data-lucide="heart-handshake" class="lucide-lg"></i>
       Sponsor
     </a></li>
@@ -39,26 +39,26 @@ title: JUnit
   <div class="col-md-4 col-sm-5">
     <h2>Latest Release</h2>
     <p>
-      <a href="https://central.sonatype.com/search?namespace=org.junit.jupiter">
+      <a rel="noopener" href="https://central.sonatype.com/search?namespace=org.junit.jupiter">
         <img alt="JUnit Jupiter version" src="https://img.shields.io/maven-central/v/org.junit.jupiter/junit-jupiter/6..svg?color=25a162&label=Jupiter">
       </a>
-      <a href="https://central.sonatype.com/search?namespace=org.junit.vintage">
+      <a  rel="noopener" href="https://central.sonatype.com/search?namespace=org.junit.vintage">
         <img alt="JUnit Vintage version" src="https://img.shields.io/maven-central/v/org.junit.vintage/junit-vintage-engine/6..svg?color=25a162&label=Vintage">
       </a>
-      <a href="https://central.sonatype.com/search?namespace=org.junit.platform">
+      <a rel="noopener" href="https://central.sonatype.com/search?namespace=org.junit.platform">
         <img alt="JUnit Platform version" src="https://img.shields.io/maven-central/v/org.junit.platform/junit-platform-commons/6..svg?color=25a162&label=Platform">
       </a>
     </p>
     <p>
       JUnit artifacts are deployed to Maven Central and can be downloaded using the above links.
-      All files are signed using the keys listed in the <a href="{{ site.current_repo_url }}/blob/main/KEYS">KEYS</a> file.
+      All files are signed using the keys listed in the <a rel="noopener" href="{{ site.current_repo_url }}/blob/main/KEYS">KEYS</a> file.
     </p>
     <h2>Upcoming Events</h2>
     <div id="events">
       <script defer type="text/javascript" src="{{ site.baseurl }}/assets/js/events.js"></script>
     </div>
     <div>
-      <a class="btn btn-default btn-xs" href="https://github.com/junit-team/junit-team.github.io/wiki/Adding-your-talk-to-the-JUnit-website" role="button">
+      <a class="btn btn-default btn-xs" rel="noopener" href="https://github.com/junit-team/junit-team.github.io/wiki/Adding-your-talk-to-the-JUnit-website" role="button">
         <i data-lucide="plus" class="lucide-lg"></i>
         Add your talk
       </a>
@@ -67,34 +67,34 @@ title: JUnit
     <p>In addition to our sponsors, we'd like to thank the following companies.</p>
     <div class="row">
       <div class="col-xs-6">
-        <p style="min-height: 50px;"><a href="https://github.com"><img alt="GitHub" src="{{ site.baseurl }}/assets/img/github.png" class="img-responsive"></a></p>
-        <p class="text-center">The JUnit team uses <a href="https://github.com">GitHub</a> for version control, project management, and CI.</p>
+        <p style="min-height: 50px;"><a rel="nofollow noopener" href="https://github.com"><img alt="GitHub" src="{{ site.baseurl }}/assets/img/github.png" class="img-responsive"></a></p>
+        <p class="text-center">The JUnit team uses <a rel="nofollow noopener" href="https://github.com">GitHub</a> for version control, project management, and CI.</p>
       </div>
       <div class="col-xs-6">
-        <p style="min-height: 50px;"><a href="https://gradle.com"><img alt="Gradle Technologies" src="/assets/img/gradle-technologies.png" class="img-responsive" style="padding-top: 6px"></a></p>
-        <p class="text-center">The JUnit team relies on <a href="https://gradle.com/develocity">Develocity</a> from Gradle Technologies to analyze and speed up our builds.</p>
+        <p style="min-height: 50px;"><a rel="nofollow noopener" href="https://gradle.com"><img alt="Gradle Technologies" src="/assets/img/gradle-technologies.png" class="img-responsive" style="padding-top: 6px"></a></p>
+        <p class="text-center">The JUnit team relies on <a rel="nofollow noopener" href="https://gradle.com/develocity">Develocity</a> from Gradle Technologies to analyze and speed up our builds.</p>
       </div>
     </div>
     <div class="row" style="margin-top: 20px;">
       <div class="col-xs-6">
-        <p style="min-height: 50px;"><a href="https://statichost.eu"><img alt="statichost.eu" src="{{ site.baseurl }}/assets/img/statichost.svg" class="img-responsive" style="width: 100%"></a></p>
-        <p class="text-center">The JUnit team uses <a href="https://statichost.eu">statichost.eu</a> for hosting our documentation and websites.</p>
+        <p style="min-height: 50px;"><a rel="nofollow noopener" href="https://statichost.eu"><img alt="statichost.eu" src="{{ site.baseurl }}/assets/img/statichost.svg" class="img-responsive" style="width: 100%"></a></p>
+        <p class="text-center">The JUnit team uses <a rel="nofollow noopener" href="https://statichost.eu">statichost.eu</a> for hosting our documentation and websites.</p>
       </div>
       <div class="col-xs-6">
-        <p style="min-height: 50px;"><a href="https://jb.gg/OpenSourceSupport"><img alt="JetBrains" src="https://resources.jetbrains.com/storage/products/company/brand/logos/jetbrains.svg" class="img-responsive" style="width: 100%"></a></p>
-        <p class="text-center">The JUnit team uses OSS licenses of <a href="https://www.jetbrains.com/idea/">IntelliJ IDEA</a> for development.</p>
+        <p style="min-height: 50px;"><a rel="nofollow noopener" href="https://jb.gg/OpenSourceSupport"><img alt="JetBrains" src="https://resources.jetbrains.com/storage/products/company/brand/logos/jetbrains.svg" class="img-responsive" style="width: 100%"></a></p>
+        <p class="text-center">The JUnit team uses OSS licenses of <a rel="nofollow noopener" href="https://www.jetbrains.com/idea/">IntelliJ IDEA</a> for development.</p>
       </div>
     </div>
     <h2>Follow Us</h2>
     <ul class="list-inline social-links">
       <li>
-        <a href="https://bsky.app/profile/junit.org">
+        <a rel="me noopener" href="https://bsky.app/profile/junit.org">
           <svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Bluesky</title><path d="M5.202 2.857C7.954 4.922 10.913 9.11 12 11.358c1.087-2.247 4.046-6.436 6.798-8.501C20.783 1.366 24 .213 24 3.883c0 .732-.42 6.156-.667 7.037-.856 3.061-3.978 3.842-6.755 3.37 4.854.826 6.089 3.562 3.422 6.299-5.065 5.196-7.28-1.304-7.847-2.97-.104-.305-.152-.448-.153-.327 0-.121-.05.022-.153.327-.568 1.666-2.782 8.166-7.847 2.97-2.667-2.737-1.432-5.473 3.422-6.3-2.777.473-5.899-.308-6.755-3.369C.42 10.04 0 4.615 0 3.883c0-3.67 3.217-2.517 5.202-1.026"/></svg>
           Bluesky
         </a>
       </li>
       <li>
-        <a rel="me" href="https://fosstodon.org/@junit">
+        <a rel="me noopener" href="https://fosstodon.org/@junit">
           <svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Mastodon</title><path d="M23.268 5.313c-.35-2.578-2.617-4.61-5.304-5.004C17.51.242 15.792 0 11.813 0h-.03c-3.98 0-4.835.242-5.288.309C3.882.692 1.496 2.518.917 5.127.64 6.412.61 7.837.661 9.143c.074 1.874.088 3.745.26 5.611.118 1.24.325 2.47.62 3.68.55 2.237 2.777 4.098 4.96 4.857 2.336.792 4.849.923 7.256.38.265-.061.527-.132.786-.213.585-.184 1.27-.39 1.774-.753a.057.057 0 0 0 .023-.043v-1.809a.052.052 0 0 0-.02-.041.053.053 0 0 0-.046-.01 20.282 20.282 0 0 1-4.709.545c-2.73 0-3.463-1.284-3.674-1.818a5.593 5.593 0 0 1-.319-1.433.053.053 0 0 1 .066-.054c1.517.363 3.072.546 4.632.546.376 0 .75 0 1.125-.01 1.57-.044 3.224-.124 4.768-.422.038-.008.077-.015.11-.024 2.435-.464 4.753-1.92 4.989-5.604.008-.145.03-1.52.03-1.67.002-.512.167-3.63-.024-5.545zm-3.748 9.195h-2.561V8.29c0-1.309-.55-1.976-1.67-1.976-1.23 0-1.846.79-1.846 2.35v3.403h-2.546V8.663c0-1.56-.617-2.35-1.848-2.35-1.112 0-1.668.668-1.67 1.977v6.218H4.822V8.102c0-1.31.337-2.35 1.011-3.12.696-.77 1.608-1.164 2.74-1.164 1.311 0 2.302.5 2.962 1.498l.638 1.06.638-1.06c.66-.999 1.65-1.498 2.96-1.498 1.13 0 2.043.395 2.74 1.164.675.77 1.012 1.81 1.012 3.12z"/></svg>
           Mastodon
         </a>


### PR DESCRIPTION
* Qualify links to project sponsors with `rel=nofollow noopener`
* Qualify links to to our socials `rel=me noopener`
* Qualify other external links with `rel=noopener`

The `nofollow` informs search engine crawlers that these links shouldn't be given any link karma. The `noopener` prevents access to the Window opener by the new destination.

Both are as far as I can tell recommended practices.

Closes: #118

1. https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/rel/noopener
2. https://developers.google.com/search/docs/crawling-indexing/qualify-outbound-links