### PR TITLE
 Add visual separation between backer names 

### DIFF
--- a/_includes/junit-sponsoring.md
+++ b/_includes/junit-sponsoring.md
@@ -179,21 +179,54 @@ Your donations will help to make that a reality!
 
 <div align="center">
   <ul class="list-inline">
-    <li class="list-inline-item"><div class="cardbacker">Stefan Gwihs</div></li>
-    <li class="list-inline-item"><div class="cardbacker">linux_china</div></li>
-    <li class="list-inline-item"><div class="cardbacker">Zerocode</div></li>
-    <li class="list-inline-item"><div class="cardbacker">Zoran Regvart</div></li>
-    <li class="list-inline-item"><div class="cardbacker">Atsushi Komiya</div></li>
-    <li class="list-inline-item"><div class="cardbacker">Peter Schuster</div></li>
-    <li class="list-inline-item"><div class="cardbacker">André Camilo</div></li>
-    <li class="list-inline-item"><div class="cardbacker">Christian Femers</div></li>
-    <li class="list-inline-item"><div class="cardbacker">Niklas Seyfarth</div></li>
-    <li class="list-inline-item"><div class="cardbacker">Ravi Vasamsetty</div></li>
-    <li class="list-inline-item"><div class="cardbacker">Jun Nakamura</div></li>
-    <li class="list-inline-item"><div class="cardbacker">Sebastian Staack</div></li>
-    <li class="list-inline-item"><div class="cardbacker">Paul Schaub</div></li>
-    <li class="list-inline-item"><div class="cardbacker">Hiroshi Ito</div></li>
-    <li class="list-inline-item"><div class="cardbacker">Gabi Moreno</div></li>
-    <li class="list-inline-item"><div class="cardbacker">Nicolai Parlog</div></li>
+    <li class="list-inline-item">
+      <div class="cardbacker">Stefan Gwihs</div>
+    </li>
+    <li class="list-inline-item">
+      <div class="cardbacker">linux_china</div>
+    </li>
+    <li class="list-inline-item">
+      <div class="cardbacker">Zerocode</div>
+    </li>
+    <li class="list-inline-item">
+      <div class="cardbacker">Zoran Regvart</div>
+    </li>
+    <li class="list-inline-item">
+      <div class="cardbacker">Atsushi Komiya</div>
+    </li>
+    <li class="list-inline-item">
+      <div class="cardbacker">Peter Schuster</div>
+    </li>
+    <li class="list-inline-item">
+      <div class="cardbacker">André Camilo</div>
+    </li>
+    <li class="list-inline-item">
+      <div class="cardbacker">Christian Femers</div>
+    </li>
+    <li class="list-inline-item">
+      <div class="cardbacker">Niklas Seyfarth</div>
+    </li>
+    <li class="list-inline-item">
+      <div class="cardbacker">Ravi Vasamsetty</div>
+    </li>
+    <li class="list-inline-item">
+      <div class="cardbacker">Jun Nakamura</div>
+    </li>
+    <li class="list-inline-item">
+      <div class="cardbacker">Sebastian Staack</div>
+    </li>
+    <li class="list-inline-item">
+      <div class="cardbacker">Paul Schaub</div>
+    </li>
+    <li class="list-inline-item">
+      <div class="cardbacker">Hiroshi Ito</div>
+    </li>
+    <li class="list-inline-item">
+      <div class="cardbacker">Gabi Moreno</div>
+    </li>
+    <li class="list-inline-item">
+      <div class="cardbacker">Nicolai Parlog</div>
+    </li>
   </ul>
 </div>
+

--- a/_includes/junit-sponsoring.md
+++ b/_includes/junit-sponsoring.md
@@ -177,21 +177,23 @@ Your donations will help to make that a reality!
 
 ### Backers
 
-<ul class="list-inline">
-  <li class="list-inline-item">Stefan Gwihs</li>
-  <li class="list-inline-item">linux_china</li>
-  <li class="list-inline-item">Zerocode</li>
-  <li class="list-inline-item">Zoran Regvart</li>
-  <li class="list-inline-item">Atsushi Komiya</li>
-  <li class="list-inline-item">Peter Schuster</li>
-  <li class="list-inline-item">André Camilo</li>
-  <li class="list-inline-item">Christian Femers</li>
-  <li class="list-inline-item">Niklas Seyfarth</li>
-  <li class="list-inline-item">Ravi Vasamsetty</li>
-  <li class="list-inline-item">Jun Nakamura</li>
-  <li class="list-inline-item">Sebastian Staack</li>
-  <li class="list-inline-item">Paul Schaub</li>
-  <li class="list-inline-item">Hiroshi Ito</li>
-  <li class="list-inline-item">Gabi Moreno</li>
-  <li class="list-inline-item">Nicolai Parlog</li>
-</ul>
+<div align="center">
+    <ul class="list-inline">
+      <li class="list-inline-item"><div class="cardbacker">Stefan Gwihs</div></li>
+      <li class="list-inline-item"><div class="cardbacker">linux_china</div></li>
+      <li class="list-inline-item"><div class="cardbacker">Zerocode</div></li>
+      <li class="list-inline-item"><div class="cardbacker">Zoran Regvart</div></li>
+      <li class="list-inline-item"><div class="cardbacker">Atsushi Komiya</div></li>
+      <li class="list-inline-item"><div class="cardbacker">Peter Schuster</div></li>
+      <li class="list-inline-item"><div class="cardbacker">André Camilo</div></li>
+      <li class="list-inline-item"><div class="cardbacker">Christian Femers</div></li>
+      <li class="list-inline-item"><div class="cardbacker">Niklas Seyfarth</div></li>
+      <li class="list-inline-item"><div class="cardbacker">Ravi Vasamsetty</div></li>
+      <li class="list-inline-item"><div class="cardbacker">Jun Nakamura</div></li>
+      <li class="list-inline-item"><div class="cardbacker">Sebastian Staack</div></li>
+      <li class="list-inline-item"><div class="cardbacker">Paul Schaub</div></li>
+      <li class="list-inline-item"><div class="cardbacker">Hiroshi Ito</div></li>
+      <li class="list-inline-item"><div class="cardbacker">Gabi Moreno</div></li>
+      <li class="list-inline-item"><div class="cardbacker">Nicolai Parlog</div></li>
+    </ul>
+</div>

--- a/_includes/junit-sponsoring.md
+++ b/_includes/junit-sponsoring.md
@@ -178,22 +178,22 @@ Your donations will help to make that a reality!
 ### Backers
 
 <div align="center">
-    <ul class="list-inline">
-      <li class="list-inline-item"><div class="cardbacker">Stefan Gwihs</div></li>
-      <li class="list-inline-item"><div class="cardbacker">linux_china</div></li>
-      <li class="list-inline-item"><div class="cardbacker">Zerocode</div></li>
-      <li class="list-inline-item"><div class="cardbacker">Zoran Regvart</div></li>
-      <li class="list-inline-item"><div class="cardbacker">Atsushi Komiya</div></li>
-      <li class="list-inline-item"><div class="cardbacker">Peter Schuster</div></li>
-      <li class="list-inline-item"><div class="cardbacker">André Camilo</div></li>
-      <li class="list-inline-item"><div class="cardbacker">Christian Femers</div></li>
-      <li class="list-inline-item"><div class="cardbacker">Niklas Seyfarth</div></li>
-      <li class="list-inline-item"><div class="cardbacker">Ravi Vasamsetty</div></li>
-      <li class="list-inline-item"><div class="cardbacker">Jun Nakamura</div></li>
-      <li class="list-inline-item"><div class="cardbacker">Sebastian Staack</div></li>
-      <li class="list-inline-item"><div class="cardbacker">Paul Schaub</div></li>
-      <li class="list-inline-item"><div class="cardbacker">Hiroshi Ito</div></li>
-      <li class="list-inline-item"><div class="cardbacker">Gabi Moreno</div></li>
-      <li class="list-inline-item"><div class="cardbacker">Nicolai Parlog</div></li>
-    </ul>
+  <ul class="list-inline">
+    <li class="list-inline-item"><div class="cardbacker">Stefan Gwihs</div></li>
+    <li class="list-inline-item"><div class="cardbacker">linux_china</div></li>
+    <li class="list-inline-item"><div class="cardbacker">Zerocode</div></li>
+    <li class="list-inline-item"><div class="cardbacker">Zoran Regvart</div></li>
+    <li class="list-inline-item"><div class="cardbacker">Atsushi Komiya</div></li>
+    <li class="list-inline-item"><div class="cardbacker">Peter Schuster</div></li>
+    <li class="list-inline-item"><div class="cardbacker">André Camilo</div></li>
+    <li class="list-inline-item"><div class="cardbacker">Christian Femers</div></li>
+    <li class="list-inline-item"><div class="cardbacker">Niklas Seyfarth</div></li>
+    <li class="list-inline-item"><div class="cardbacker">Ravi Vasamsetty</div></li>
+    <li class="list-inline-item"><div class="cardbacker">Jun Nakamura</div></li>
+    <li class="list-inline-item"><div class="cardbacker">Sebastian Staack</div></li>
+    <li class="list-inline-item"><div class="cardbacker">Paul Schaub</div></li>
+    <li class="list-inline-item"><div class="cardbacker">Hiroshi Ito</div></li>
+    <li class="list-inline-item"><div class="cardbacker">Gabi Moreno</div></li>
+    <li class="list-inline-item"><div class="cardbacker">Nicolai Parlog</div></li>
+  </ul>
 </div>

--- a/_includes/junit-sponsoring.md
+++ b/_includes/junit-sponsoring.md
@@ -180,52 +180,84 @@ Your donations will help to make that a reality!
 <div align="center">
   <ul class="list-inline">
     <li class="list-inline-item">
-      <div class="cardbacker">Stefan Gwihs</div>
+      <div class="cardbacker">
+        Stefan Gwihs
+      </div>
     </li>
     <li class="list-inline-item">
-      <div class="cardbacker">linux_china</div>
+      <div class="cardbacker">
+        linux_china
+      </div>
     </li>
     <li class="list-inline-item">
-      <div class="cardbacker">Zerocode</div>
+      <div class="cardbacker">
+        Zerocode
+      </div>
     </li>
     <li class="list-inline-item">
-      <div class="cardbacker">Zoran Regvart</div>
+      <div class="cardbacker">
+        Zoran Regvart
+      </div>
     </li>
     <li class="list-inline-item">
-      <div class="cardbacker">Atsushi Komiya</div>
+      <div class="cardbacker">
+        Atsushi Komiya
+      </div>
     </li>
     <li class="list-inline-item">
-      <div class="cardbacker">Peter Schuster</div>
+      <div class="cardbacker">
+        Peter Schuster
+      </div>
     </li>
     <li class="list-inline-item">
-      <div class="cardbacker">André Camilo</div>
+      <div class="cardbacker">
+        André Camilo
+      </div>
     </li>
     <li class="list-inline-item">
-      <div class="cardbacker">Christian Femers</div>
+      <div class="cardbacker">
+        Christian Femers
+      </div>
     </li>
     <li class="list-inline-item">
-      <div class="cardbacker">Niklas Seyfarth</div>
+      <div class="cardbacker">
+        Niklas Seyfarth
+      </div>
     </li>
     <li class="list-inline-item">
-      <div class="cardbacker">Ravi Vasamsetty</div>
+      <div class="cardbacker">
+        Ravi Vasamsetty
+      </div>
     </li>
     <li class="list-inline-item">
-      <div class="cardbacker">Jun Nakamura</div>
+      <div class="cardbacker">
+        Jun Nakamura
+      </div>
     </li>
     <li class="list-inline-item">
-      <div class="cardbacker">Sebastian Staack</div>
+      <div class="cardbacker">
+        Sebastian Staack
+      </div>
     </li>
     <li class="list-inline-item">
-      <div class="cardbacker">Paul Schaub</div>
+      <div class="cardbacker">
+        Paul Schaub
+      </div>
     </li>
     <li class="list-inline-item">
-      <div class="cardbacker">Hiroshi Ito</div>
+      <div class="cardbacker">
+        Hiroshi Ito
+      </div>
     </li>
     <li class="list-inline-item">
-      <div class="cardbacker">Gabi Moreno</div>
+      <div class="cardbacker">
+        Gabi Moreno
+      </div>
     </li>
     <li class="list-inline-item">
-      <div class="cardbacker">Nicolai Parlog</div>
+      <div class="cardbacker">
+        Nicolai Parlog
+      </div>
     </li>
   </ul>
 </div>

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -205,7 +205,7 @@ footer {
 }
 
 .cardsilver-center {
-    display: block;
+    display: none;
     width: 100%;
     height: 40px;
     overflow: hidden;
@@ -258,7 +258,7 @@ footer {
 }
 
 .cardbronze-center {
-    display: block;
+    display: none;
     width: 100%;
     height: 40px;
     overflow: hidden;
@@ -277,6 +277,3 @@ footer {
     font-size: 1.2rem;
 }
 
-.cardsilver-center, .cardbronze-center {
-    display: none;
-}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -277,3 +277,12 @@ footer {
     font-size: 1.2rem;
 }
 
+
+/* Backer card style
+-------------------------------------------------- */
+
+.cardbacker {
+    width: 180px;
+    margin: 10px 1px;
+    text-align: center;
+}


### PR DESCRIPTION
Before:

<img width="986" height="1154" alt="image" src="https://github.com/user-attachments/assets/de172464-9a6b-4318-8fae-6896661cb5fc" />

After:

<img width="986" height="1154" alt="Screenshot From 2026-06-24 18-18-49" src="https://github.com/user-attachments/assets/317c0c5f-866c-4106-9dd3-3aea2633ce03" />

And when compressed:

<img width="898" height="947" alt="Screenshot From 2026-06-24 18-19-08" src="https://github.com/user-attachments/assets/abdb0906-54b6-4f55-85a2-8173fd7b9824" />
